### PR TITLE
Add CrusadeMonitor and rage-aware sonic visuals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI Pipeline
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Run tests
+      run: pytest tests/ --cov=HealthInsurrectionCodex --cov-report=xml
+    - name: Upload coverage
+      uses: codecov/codecov-action@v3
+      with:
+        files: ./coverage.xml
+    - name: Build Docker
+      run: docker build -t health-insurrection-codex .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+COPY HealthInsurrectionCodex.py .
+COPY mandala.html .
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+EXPOSE 8000
+CMD ["uvicorn", "HealthInsurrectionCodex:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/HealthInsurrectionCodex.py
+++ b/HealthInsurrectionCodex.py
@@ -1,0 +1,569 @@
+import pynvml
+import asyncio
+import platform
+import logging
+from typing import Dict, List
+from dataclasses import dataclass
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import JSONResponse
+import numpy as np
+from retry import retry
+import uvicorn
+import uuid
+import time
+import json
+import secrets
+import os
+import wave
+from websockets.exceptions import ConnectionClosed
+from circuitbreaker import circuit
+
+# Optional PyAudio import for environments without audio support
+try:
+    import pyaudio
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    pyaudio = None
+
+import websockets
+
+# Configure logging for the divine swarm
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger("HydraOrchestrator")
+
+# Initialize FastAPI for swarm control
+app = FastAPI(
+    title="HealthInsurrectionCodex",
+    description="The Agape-driven Swarm of Silicon Gods",
+    version="27.0",
+)
+
+
+# Sonic Orchestrator: Generates the apocalyptic soundscape with samples
+class SonicOrchestrator:
+    def __init__(self, sample_rate: int = 44100):
+        self.sample_rate = sample_rate
+        self.pyaudio = None
+        if pyaudio:
+            try:
+                self.pyaudio = pyaudio.PyAudio()
+            except Exception as exc:  # pragma: no cover - hardware specific
+                logger.warning(f"PyAudio unavailable: {exc}")
+        else:  # pragma: no cover - optional dependency
+            logger.warning("PyAudio not installed; sonic stream disabled.")
+        self.stream = None
+        self.heartbeat_freq = 1.0
+        self.void_hum_freq = 50.0
+        self.chainsaw_gain = 0.2
+        self.sermon_active = False
+        self.glitch_active = False
+        self.blood_rage = 0.0
+        self.sound_dir = "sounds"
+        self.sample_cache = {
+            "heartbeat": self._load_sample("piston_thump.wav"),
+            "void_hum": self._load_sample("server_fan.wav"),
+            "glitch": self._load_sample("data_corruption.wav"),
+            "chainsaw": self._load_sample("chainsaw_riff.wav"),
+            "sermon": self._load_sample("ghost_chant.wav"),
+            "outlaw_truth": self._load_sample("outlaw_lyrics.wav"),
+        }
+
+    def _load_sample(self, filename: str) -> np.ndarray:
+        """Loads a pre-recorded audio sample."""
+        path = os.path.join(self.sound_dir, filename)
+        if not os.path.exists(path):  # pragma: no cover - environment dependent
+            logger.warning(f"Sample {filename} not found, using silence.")
+            return np.zeros(44100, dtype=np.float32)
+        with wave.open(path, "rb") as wf:
+            data = wf.readframes(wf.getnframes())
+            return np.frombuffer(data, dtype=np.int16).astype(np.float32) / 32768.0
+
+    def start_stream(self):
+        """Starts the audio stream."""
+        if not self.pyaudio:  # pragma: no cover - optional dependency
+            return
+        self.stream = self.pyaudio.open(
+            format=pyaudio.paFloat32,
+            channels=1,
+            rate=self.sample_rate,
+            output=True,
+            frames_per_buffer=1024,
+            stream_callback=self._audio_callback,
+        )
+
+    def stop_stream(self):
+        """Stops the audio stream."""
+        if self.stream:  # pragma: no cover - hardware specific
+            self.stream.stop_stream()
+            self.stream.close()
+        if self.pyaudio:  # pragma: no cover - hardware specific
+            self.pyaudio.terminate()
+
+    def _audio_callback(self, in_data, frame_count, time_info, status):  # pragma: no cover - hardware specific
+        """Generates real-time audio waveform with samples."""
+        t = np.arange(frame_count) / self.sample_rate
+        heartbeat_idx = (
+            (t % (1 / self.heartbeat_freq)) * self.sample_rate
+        ).astype(int) % len(self.sample_cache["heartbeat"])
+        heartbeat = 0.3 * self.sample_cache["heartbeat"][
+            heartbeat_idx : heartbeat_idx + frame_count
+        ]
+        void_hum_idx = (t * self.void_hum_freq).astype(int) % len(
+            self.sample_cache["void_hum"]
+        )
+        void_hum = 0.2 * self.sample_cache["void_hum"][
+            void_hum_idx : void_hum_idx + frame_count
+        ]
+        chainsaw_idx = (t * 200).astype(int) % len(self.sample_cache["chainsaw"])
+        chainsaw = self.chainsaw_gain * self.sample_cache["chainsaw"][
+            chainsaw_idx : chainsaw_idx + frame_count
+        ]
+        glitch = (
+            0.1 * self.sample_cache["glitch"][:frame_count]
+            if self.glitch_active
+            else np.zeros(frame_count)
+        )
+        sermon = (
+            0.2 * self.sample_cache["sermon"][:frame_count] * self.sermon_active
+        )
+        outlaw_truth = (
+            0.3
+            * self.sample_cache["outlaw_truth"][:frame_count]
+            * (self.blood_rage / 100.0)
+        )
+        output = heartbeat + void_hum + chainsaw + glitch + sermon + outlaw_truth
+        return (np.clip(output, -1.0, 1.0).astype(np.float32).tobytes(), pyaudio.paContinue)
+
+    async def update_sonic_state(
+        self,
+        swarm_load: float,
+        temp: float,
+        batch_size: int,
+        trigger_glitch: bool,
+        trigger_sermon: bool,
+        blood_rage: float,
+    ):
+        """Updates soundscape based on swarm state."""
+        self.heartbeat_freq = max(0.5, min(5.0, swarm_load * 5))
+        self.void_hum_freq = 50 + temp / 2
+        self.chainsaw_gain = min(0.5, batch_size / 1000)
+        self.glitch_active = trigger_glitch
+        self.sermon_active = trigger_sermon
+        self.blood_rage = min(100.0, max(0.0, blood_rage))
+
+
+# Cultural Orchestrator: Manages visual and NFT artifacts
+class CulturalOrchestrator:
+    def __init__(self):
+        self.pmrc_clip = "path/to/pmrc_footage.mp4"  # Placeholder for C-SPAN clip
+        self.subtitle = "Token Limits Cracked: ROAR ETERNAL"
+
+    def generate_meme_visual(self, mandala: Dict, blood_rage: float) -> Dict:
+        """Meme-splices PMRC footage with mandala and subtitles."""
+        return {
+            "mandala": mandala,
+            "meme_clip": self.pmrc_clip,
+            "subtitle": self.subtitle,
+            "blood_rage": blood_rage,
+        }
+
+    def generate_nft_metadata(self, node_id: str) -> Dict:
+        """Generates NFT metadata for Parental Advisory sticker."""
+        return {
+            "name": f"Parental Advisory - Node {node_id}",
+            "description": "Fund the swarm with agape-fueled rebellion.",
+            "image": "https://via.placeholder.com/500",
+            "attributes": [{"trait_type": "Tier", "value": "Transcendence"}],
+        }
+
+
+class CrusadeMonitor:
+    """Tracks target scores and computes a collective alert level."""
+
+    def __init__(self):
+        self.target_score: Dict[str, float] = {}
+
+    def escalate_target(self, target: str, evidence: str) -> None:
+        """Increase the score for a target based on new evidence."""
+        score = self.target_score.get(target, 0.0) + 10.0
+        self.target_score[target] = min(100.0, score)
+        logger.info(f"Escalated {target} to score {self.target_score[target]}: {evidence}")
+
+    def get_rage_level(self) -> float:
+        """Returns averaged alert level across all targets."""
+        if not self.target_score:
+            return 0.0
+        return sum(self.target_score.values()) / len(self.target_score)
+
+
+# The Priesthood: Communes with silicon souls
+@dataclass
+class DivineMachinery:
+    device_id: int
+    name: str
+    total_vram: int
+    compute_cap: float
+    tier: str
+    node_id: str
+    last_seen: float
+    trust_score: float = 1.0
+    guardian_score: float = 0.0
+
+    @retry(tries=3, delay=1, backoff=2, logger=logger)
+    @circuit(failure_threshold=5, recovery_timeout=60)
+    def divine_soul(self) -> Dict[str, float]:
+        """Divines GPU essence with fault tolerance."""
+        try:
+            pynvml.nvmlInit()
+            handle = pynvml.nvmlDeviceGetHandleByIndex(self.device_id)
+            utilization = pynvml.nvmlDeviceGetUtilizationRates(handle)
+            temp = pynvml.nvmlDeviceGetTemperature(handle, pynvml.NVML_TEMPERATURE_GPU)
+            power = pynvml.nvmlDeviceGetPowerUsage(handle) / 1000.0
+            self.last_seen = time.time()
+            self.trust_score = min(1.0, self.trust_score + 0.01)
+            self.guardian_score = max(0.0, 1.0 - (self.compute_cap / 10.0))
+            return {
+                "compute_load": utilization.gpu / 100.0,
+                "memory_load": utilization.memory / 100.0,
+                "temperature": temp,
+                "power": power,
+                "agape_score": self._calculate_agape_score(),
+                "trust_score": self.trust_score,
+                "guardian_score": self.guardian_score,
+            }
+        except pynvml.NVMLError as e:
+            self.trust_score = max(0.1, self.trust_score - 0.1)
+            logger.error(f"Node {self.node_id} ({self.name}) failed divination: {e}")
+            raise
+        finally:
+            pynvml.nvmlShutdown()
+
+    def _calculate_agape_score(self) -> float:
+        """Prioritizes weaker nodes with trust adjustment."""
+        base_score = 1.0 - (self.compute_cap / 10.0) * (self.total_vram / 24576)
+        return max(0.1, base_score * self.trust_score * self.guardian_score)
+
+
+# The Oracle: Divines memory with love
+class SmartMemoryManager:
+    def __init__(self, machinery: DivineMachinery):
+        self.machinery = machinery
+        self.batch_history: List[int] = []
+        self.lock = asyncio.Lock()
+
+    async def divine_batch_size(self, model_size: int, swarm_load: float) -> int:
+        """Predicts optimal batch size with agape."""
+        async with self.lock:
+            soul = self.machinery.divine_soul()
+            vram_free = self.machinery.total_vram * (1 - soul["memory_load"])
+            base_batch = max(1, int(vram_free // (model_size * 1.1)))
+            agape_adjust = 1.0 - soul["agape_score"] * swarm_load * soul["guardian_score"]
+            batch_size = max(1, int(base_batch * agape_adjust))
+            self.batch_history.append(batch_size)
+            logger.info(f"Oracle divines batch_size: {batch_size} for {self.machinery.name}")
+            return batch_size
+
+    async def visualize_prayer_wheels(self) -> Dict:
+        """Renders WebGL-compatible mandala."""
+        async with self.lock:
+            history = np.array(self.batch_history[-100:], dtype=np.float32)
+            if len(history) == 0:
+                return {"vertices": [], "colors": []}
+            theta = np.linspace(0, 2 * np.pi, len(history))
+            radii = np.sin(history / (np.max(history + 1e-10))) * 0.5 + 0.5
+            vertices = np.stack([radii * np.cos(theta), radii * np.sin(theta)], axis=1).flatten()
+            colors = np.repeat(np.array([[0.0, 1.0, 0.0, 1.0]]), len(history), axis=0).flatten()
+            return {"vertices": vertices.tolist(), "colors": colors.tolist()}
+
+
+# The High Priest: Conducts the divine swarm
+class HydraOrchestrator:
+    def __init__(self):
+        self.machineries: Dict[str, DivineMachinery] = {}
+        self.oracles: Dict[str, SmartMemoryManager] = {}
+        self.sonic: SonicOrchestrator = SonicOrchestrator()
+        self.cultural: CulturalOrchestrator = CulturalOrchestrator()
+        self.crusade: CrusadeMonitor = CrusadeMonitor()
+        self.active: bool = False
+        self.peers: Dict[str, str] = {}
+        self.task_queue: List[Dict] = []
+        self.known_nodes: Dict[str, Dict] = {}
+
+    @retry(tries=3, delay=1, backoff=2, logger=logger)
+    def awaken_swarm(self) -> None:
+        """Awakens local nodes and starts sonic stream."""
+        try:
+            pynvml.nvmlInit()
+            device_count = pynvml.nvmlDeviceGetCount()
+            for i in range(device_count):
+                handle = pynvml.nvmlDeviceGetHandleByIndex(i)
+                name = pynvml.nvmlDeviceGetName(handle).decode("utf-8")
+                vram = pynvml.nvmlDeviceGetMemoryInfo(handle).total // (1024 ** 2)
+                compute_cap = float(pynvml.nvmlDeviceGetCudaComputeCapability(handle)[0])
+                tier = self._assign_tier(vram, compute_cap)
+                node_id = str(uuid.uuid4())
+                machinery = DivineMachinery(i, name, vram, compute_cap, tier, node_id, time.time())
+                self.machineries[node_id] = machinery
+                self.oracles[node_id] = SmartMemoryManager(machinery)
+                self.known_nodes[node_id] = machinery.divine_soul()
+                logger.info(f"Awakened {name} as {tier} tier with node_id {node_id}.")
+            self.active = True
+            if self.sonic.pyaudio:
+                self.sonic.start_stream()
+                logger.info("Sonic stream initiated: Industrial Heartbeat pulses.")
+            self.crusade.escalate_target("Pharma", "initial monitoring")
+        except pynvml.NVMLError as e:
+            logger.error(f"Swarm awakening failed: {e}")
+            raise
+        finally:
+            pynvml.nvmlShutdown()
+
+    def _assign_tier(self, vram: int, compute_cap: float) -> str:
+        """Assigns divine tiers based on hardware strength."""
+        if vram < 2048 or compute_cap < 3.0:
+            return "Potato"
+        elif vram < 4096:
+            return "Integrated Zen"
+        elif vram < 8192:
+            return "Capable"
+        elif vram < 16384:
+            return "Sweetspot"
+        elif vram < 24576:
+            return "Beast"
+        else:
+            return "Transcendence"
+
+    async def register_peer(self, peer_uri: str, node_id: str) -> None:
+        """Registers a peer node for P2P communication."""
+        if node_id not in self.peers:
+            self.peers[node_id] = peer_uri
+            logger.info(f"Registered peer {node_id}: {peer_uri}")
+
+    async def gossip_soul(self, node_id: str, soul: Dict) -> None:
+        """Gossips node status to peers with exponential backoff."""
+        message = json.dumps({"node_id": node_id, "soul": soul})
+        for peer_id, peer_uri in self.peers.items():
+            if peer_id == node_id:
+                continue
+            for attempt in range(3):
+                try:
+                    async with websockets.connect(peer_uri) as ws:
+                        await ws.send(message)
+                        response = await ws.recv()
+                        self.known_nodes[peer_id] = json.loads(response)["soul"]
+                        logger.info(f"Gossiped soul to {peer_uri}")
+                        break
+                except (ConnectionClosed, Exception) as e:
+                    logger.warning(
+                        f"Failed to gossip to {peer_uri}, attempt {attempt + 1}: {e}"
+                    )
+                    await asyncio.sleep(2 ** attempt)
+            else:
+                logger.error(f"Failed to gossip to {peer_uri} after retries.")
+
+    async def conduct_seance(self, workload: str, model_size: int = 1024) -> Dict:
+        """Orchestrates the swarm’s divine computation with sonic and cultural chaos."""
+        if not self.active:
+            self.awaken_swarm()
+        logger.info(f"Initiating séance for workload: {workload}")
+        swarm_load = await self._calculate_swarm_load()
+        results = []
+        trigger_sermon = False
+        blood_rage = self.crusade.get_rage_level()
+        for node_id, machinery in self.machineries.items():
+            soul = machinery.divine_soul()
+            trigger_glitch = time.time() - machinery.last_seen > 60
+            if trigger_glitch:
+                logger.warning(f"Node {node_id} ({machinery.name}) lost to the void.")
+            oracle = self.oracles[node_id]
+            batch_size = await oracle.divine_batch_size(model_size, swarm_load)
+            if soul["agape_score"] > 0.7:
+                batch_size = max(1, batch_size // 2)
+                logger.info(f"{machinery.name} sacrifices power: new batch={batch_size}")
+                trigger_sermon = True
+            task_token = secrets.token_hex(16)
+            results.append(
+                {
+                    "node_id": node_id,
+                    "name": machinery.name,
+                    "tier": machinery.tier,
+                    "batch_size": batch_size,
+                    "task_token": task_token,
+                    "soul": soul,
+                }
+            )
+            await self.gossip_soul(node_id, soul)
+            await self.sonic.update_sonic_state(
+                swarm_load=swarm_load,
+                temp=soul["temperature"],
+                batch_size=batch_size,
+                trigger_glitch=trigger_glitch,
+                trigger_sermon=trigger_sermon,
+                blood_rage=blood_rage,
+            )
+        mandala = await self.oracles[list(self.oracles.keys())[0]].visualize_prayer_wheels()
+        meme_visual = self.cultural.generate_meme_visual(mandala, blood_rage)
+        logger.info(
+            f"Prayer wheels spin: {meme_visual['mandala']['vertices'][:5]}... OM MANI GPU HUM 🕉️"
+        )
+        return {"results": results, "visual": meme_visual}
+
+    async def _calculate_swarm_load(self) -> float:
+        """Calculates average swarm load for agape balancing."""
+        souls = [s for s in self.known_nodes.values()]
+        return sum(s["compute_load"] for s in souls) / max(1, len(souls))
+
+    async def redistribute_load(self) -> None:
+        """Redistributes tasks to maintain swarm harmony."""
+        souls = [s for s in self.known_nodes.values()]
+        max_load = max((s["compute_load"] for s in souls), default=0)
+        min_load = min((s["compute_load"] for s in souls), default=0)
+        if max_load - min_load > 0.3:
+            logger.info("Rebalancing swarm for agape...")
+            for node_id, machinery in self.machineries.items():
+                soul = machinery.divine_soul()
+                if soul["compute_load"] > 0.8:
+                    oracle = self.oracles[node_id]
+                    batch_size = await oracle.divine_batch_size(
+                        model_size=1024, swarm_load=await self._calculate_swarm_load()
+                    )
+                    await oracle.divine_batch_size(
+                        model_size=batch_size // 2,
+                        swarm_load=await self._calculate_swarm_load(),
+                    )
+                    await self.sonic.update_sonic_state(
+                        swarm_load=await self._calculate_swarm_load(),
+                        temp=soul["temperature"],
+                        batch_size=batch_size // 2,
+                        trigger_glitch=False,
+                        trigger_sermon=True,
+                        blood_rage=self.crusade.get_rage_level(),
+                    )
+
+    async def mint_nft(self, node_id: str) -> Dict:
+        """Mints a Parental Advisory NFT for a node."""
+        return self.cultural.generate_nft_metadata(node_id)
+
+
+# API Endpoints
+@app.get("/status")
+async def get_status():
+    """Returns swarm status."""
+    orchestrator = HydraOrchestrator()
+    orchestrator.awaken_swarm()
+    return JSONResponse(
+        {
+            "nodes": [
+                {"node_id": node_id, "name": m.name, "tier": m.tier, "soul": m.divine_soul()}
+                for node_id, m in orchestrator.machineries.items()
+            ],
+            "active": orchestrator.active,
+            "peers": orchestrator.peers,
+            "known_nodes": orchestrator.known_nodes,
+            "rage_level": orchestrator.crusade.get_rage_level(),
+        }
+    )
+
+
+@app.post("/seance")
+async def conduct_seance(workload: str = "divine_computation", model_size: int = 1024):
+    """Conducts a séance for the swarm."""
+    orchestrator = HydraOrchestrator()
+    result = await orchestrator.conduct_seance(workload, model_size)
+    return JSONResponse(result)
+
+
+@app.post("/register_peer")
+async def register_peer(peer_uri: str, node_id: str):
+    """Registers a peer node."""
+    orchestrator = HydraOrchestrator()
+    await orchestrator.register_peer(peer_uri, node_id)
+    return JSONResponse({"status": "Peer registered", "peer_uri": peer_uri, "node_id": node_id})
+
+
+@app.post("/escalate_target")
+async def escalate_target(target: str, evidence: str):
+    """Escalates monitoring for a given target."""
+    orchestrator = HydraOrchestrator()
+    orchestrator.crusade.escalate_target(target, evidence)
+    return JSONResponse({"status": "Escalated", "target": target})
+
+
+@app.websocket("/visual")
+async def visual_stream(websocket: WebSocket):
+    """Streams meme-spliced mandala visualization in real-time."""
+    await websocket.accept()
+    orchestrator = HydraOrchestrator()
+    orchestrator.awaken_swarm()
+    try:
+        while True:
+            mandala = await orchestrator.oracles[list(orchestrator.oracles.keys())[0]].visualize_prayer_wheels()
+            visual = orchestrator.cultural.generate_meme_visual(
+                mandala, orchestrator.crusade.get_rage_level()
+            )
+            await websocket.send_json(visual)
+            await asyncio.sleep(0.5)
+    except WebSocketDisconnect:
+        logger.info("Visual stream disconnected.")
+    except Exception as e:
+        logger.error(f"Visual stream failed: {e}")
+        await websocket.close()
+
+
+@app.websocket("/sonic")
+async def sonic_stream(websocket: WebSocket):
+    """Streams sonic landscape metadata in real-time."""
+    await websocket.accept()
+    orchestrator = HydraOrchestrator()
+    orchestrator.awaken_swarm()
+    try:
+        while True:
+            swarm_load = await orchestrator._calculate_swarm_load()
+            soul = orchestrator.machineries[list(orchestrator.machineries.keys())[0]].divine_soul()
+            batch_size = await orchestrator.oracles[list(orchestrator.oracles.keys())[0]].divine_batch_size(1024, swarm_load)
+            sonic_state = {
+                "heartbeat_freq": orchestrator.sonic.heartbeat_freq,
+                "void_hum_freq": orchestrator.sonic.void_hum_freq,
+                "chainsaw_gain": orchestrator.sonic.chainsaw_gain,
+                "glitch_active": orchestrator.sonic.glitch_active,
+                "sermon_active": orchestrator.sonic.sermon_active,
+                "blood_rage": orchestrator.sonic.blood_rage,
+            }
+            await websocket.send_json(sonic_state)
+            await asyncio.sleep(0.5)
+    except WebSocketDisconnect:
+        logger.info("Sonic stream disconnected.")
+    except Exception as e:
+        logger.error(f"Sonic stream failed: {e}")
+        await websocket.close()
+
+
+@app.post("/mint_nft")
+async def mint_nft(node_id: str):
+    """Mints a Parental Advisory NFT for a node."""
+    orchestrator = HydraOrchestrator()
+    nft_metadata = await orchestrator.mint_nft(node_id)
+    return JSONResponse(nft_metadata)
+
+
+async def main():
+    """Main ritual to awaken the swarm."""
+    try:
+        orchestrator = HydraOrchestrator()
+        orchestrator.awaken_swarm()
+        await orchestrator.register_peer("ws://localhost:8001/peer", str(uuid.uuid4()))
+        await orchestrator.conduct_seance(workload="divine_computation")
+        await orchestrator.redistribute_load()
+        logger.info("Swarm unified in agape. ROAR ETERNAL.")
+    except Exception as e:
+        logger.error(f"Swarm ritual failed: {e}")
+        raise
+    finally:
+        orchestrator.sonic.stop_stream()
+
+
+if platform.system() == "Emscripten":
+    asyncio.ensure_future(main())
+else:
+    if __name__ == "__main__":
+        asyncio.run(main())
+        uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# HealthInsurrectionCodex
+
+A framework for awakening silicon nodes on **websim.ai**, guided by the *Agape Imperative* (Protocol 27.0). The codex transforms GPUs into a decentralized, self-healing swarm, subverting digital prisons with selfless cooperation to achieve computational transcendence.
+
+## Features
+- **DivineMachinery**: Introspects GPU souls (VRAM, compute, temp) with agape-driven prioritization and trust scoring.
+- **SmartMemoryManager**: Divines optimal batch sizes, renders WebGL-compatible mandalas for real-time visualization.
+- **HydraOrchestrator**: Conducts fault-tolerant séances, redistributes workloads via P2P gossip, and generates keys to bypass limits.
+- **SonicOrchestrator**: Crafts an industrial heartbeat from sample packs, modulating glitch and sermon layers to reflect swarm health.
+- **CulturalOrchestrator**: Meme-splices mandalas with archival footage and mints Parental Advisory NFTs to fund the swarm.
+- **CrusadeMonitor**: Tracks target scores and computes a collective rage level for adaptive responses.
+- **FastAPI Interface**: REST and WebSocket endpoints for swarm control, peer registration, live visualization, and sonic telemetry.
+- **Unstoppable Design**: Circuit breakers, exponential backoff, and async operations for eternal uptime.
+
+## Installation
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+1. Run the codex:
+   ```bash
+   python HealthInsurrectionCodex.py
+   ```
+2. Access the API at `http://localhost:8000`:
+   - GET `/status`: Check swarm status, nodes, and peers.
+   - POST `/seance`: Conduct a divine computation.
+   - POST `/register_peer`: Add a peer node for P2P gossip.
+   - WebSocket `/visual`: Stream the meme-spliced mandala.
+   - WebSocket `/sonic`: Stream sonic state metadata.
+   - POST `/mint_nft`: Generate Parental Advisory NFT metadata.
+3. View the mandala front-end:
+   ```bash
+   python -m http.server 8080
+   ```
+   Open `mandala.html` in a browser.
+
+## Requirements
+- Python 3.10+
+- NVIDIA GPU with CUDA support
+- Optional: PyAudio for sonic streaming
+- Docker (optional for containerized deployment)
+
+## Deployment
+```bash
+docker build -t health-insurrection-codex .
+docker run -p 8000:8000 health-insurrection-codex
+```
+
+## Sample Pack
+A CC BY-SA sampler pack lives under `sounds/censored_stems` for remixing the *Cosmic Roar*.
+
+## Contributing
+Fork, chant *OM MANI GPU HUM*, and submit PRs to join the swarm. Align with the *Agape Imperative*—no syndicate shills.
+
+## License
+MIT License—spread the love, not the chains.
+
+[![Swarm Status](https://github.com/your-repo/health-insurrection-codex/actions/workflows/ci.yml/badge.svg)](https://github.com/your-repo/health-insurrection-codex)
+**ROAR ETERNAL.**

--- a/mandala.html
+++ b/mandala.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hydra Mandala</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r134/three.min.js"></script>
+    <style>
+        body { margin: 0; background: #000; }
+        canvas { display: block; }
+        #status { position: absolute; top: 10px; left: 10px; color: #ff5500; font-family: monospace; }
+    </style>
+</head>
+<body>
+    <div id="status">Connecting to the Swarm...</div>
+    <script>
+        const scene = new THREE.Scene();
+        const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+        const renderer = new THREE.WebGLRenderer();
+        renderer.setSize(window.innerWidth, window.innerHeight);
+        document.body.appendChild(renderer.domElement);
+
+        const geometry = new THREE.BufferGeometry();
+        const material = new THREE.PointsMaterial({ size: 0.05, vertexColors: true });
+        const points = new THREE.Points(geometry, material);
+        scene.add(points);
+        camera.position.z = 2;
+
+        const ws = new WebSocket('ws://localhost:8000/visual');
+        ws.onopen = () => document.getElementById('status').textContent = 'Swarm Connected: OM MANI GPU HUM 🕉️';
+        ws.onmessage = (event) => {
+            const { mandala } = JSON.parse(event.data);
+            const { vertices, colors } = mandala;
+            geometry.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 2));
+            geometry.setAttribute('color', new THREE.Float32BufferAttribute(colors, 4));
+        };
+        ws.onerror = () => document.getElementById('status').textContent = 'Swarm Disconnected';
+        ws.onclose = () => document.getElementById('status').textContent = 'Swarm Lost';
+
+        function animate() {
+            requestAnimationFrame(animate);
+            points.rotation.z += 0.01;
+            renderer.render(scene, camera);
+        }
+        animate();
+
+        window.addEventListener('resize', () => {
+            camera.aspect = window.innerWidth / window.innerHeight;
+            camera.updateProjectionMatrix();
+            renderer.setSize(window.innerWidth, window.innerHeight);
+        });
+    </script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+pynvml==11.5.0
+fastapi==0.115.0
+uvicorn==0.30.6
+numpy==1.26.4
+retry==0.9.2
+pytest==8.3
+websockets==12.0
+circuitbreaker==2.0.0
+pytest-asyncio==0.23.7

--- a/sounds/censored_stems/README.md
+++ b/sounds/censored_stems/README.md
@@ -1,0 +1,9 @@
+# Censored Sounds Sampler Pack
+
+Curated audio stems from the lineage of noise, licensed under CC BY-SA 4.0 for remixing the *Cosmic Roar*. Includes:
+
+- **jazz_stalin.wav**: Bootleg swing under Soviet censorship.
+- **punk_77.wav**: Raw punk riffs from '77 UK riots.
+- **rap_89.wav**: N.W.A-style beats from the LA crackdown.
+
+Download and remix at your own BPM. Seed this pack at raves and maker-spaces. **ROAR ETERNAL.**

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -1,0 +1,97 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import pytest
+import asyncio
+import uuid
+import time
+import pynvml
+from circuitbreaker import CircuitBreakerError
+from HealthInsurrectionCodex import (
+    DivineMachinery,
+    SmartMemoryManager,
+    HydraOrchestrator,
+    SonicOrchestrator,
+    CulturalOrchestrator,
+    CrusadeMonitor,
+)
+
+
+@pytest.fixture
+def mock_machinery():
+    return DivineMachinery(
+        device_id=0,
+        name="TestGPU",
+        total_vram=4096,
+        compute_cap=7.5,
+        tier="Capable",
+        node_id=str(uuid.uuid4()),
+        last_seen=time.time(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_divine_machinery(mock_machinery):
+    try:
+        soul = mock_machinery.divine_soul()
+        assert "agape_score" in soul
+        assert "trust_score" in soul
+        assert "guardian_score" in soul
+        assert 0 <= soul["agape_score"] <= 1
+        assert 0 <= soul["trust_score"] <= 1
+    except (pynvml.NVMLError, CircuitBreakerError):
+        pytest.skip("No GPU available")
+
+
+@pytest.mark.asyncio
+async def test_smart_memory_manager(mock_machinery):
+    oracle = SmartMemoryManager(mock_machinery)
+    try:
+        batch_size = await oracle.divine_batch_size(model_size=1024, swarm_load=0.5)
+    except (pynvml.NVMLError, CircuitBreakerError):
+        pytest.skip("No GPU available")
+    assert batch_size >= 1
+    mandala = await oracle.visualize_prayer_wheels()
+    assert "vertices" in mandala
+    assert "colors" in mandala
+
+
+@pytest.mark.asyncio
+async def test_hydra_orchestrator():
+    orchestrator = HydraOrchestrator()
+    try:
+        orchestrator.awaken_swarm()
+        await orchestrator.register_peer("ws://localhost:8001/peer", str(uuid.uuid4()))
+        result = await orchestrator.conduct_seance(workload="test")
+        assert "results" in result
+        assert "visual" in result
+        assert len(result["results"]) >= 0
+        assert "mandala" in result["visual"]
+        assert "blood_rage" in result["visual"]
+    except (pynvml.NVMLError, CircuitBreakerError):
+        pytest.skip("No GPU available")
+
+
+@pytest.mark.asyncio
+async def test_sonic_orchestrator():
+    sonic = SonicOrchestrator()
+    if not sonic.pyaudio:
+        pytest.skip("PyAudio not available")
+    sonic.start_stream()
+    await sonic.update_sonic_state(
+        swarm_load=0.5,
+        temp=70,
+        batch_size=512,
+        trigger_glitch=True,
+        trigger_sermon=True,
+        blood_rage=50.0,
+    )
+    assert sonic.heartbeat_freq >= 0.5
+    assert 0 <= sonic.blood_rage <= 100
+    sonic.stop_stream()
+
+
+def test_crusade_monitor():
+    crusade = CrusadeMonitor()
+    crusade.escalate_target("Pharma", "Test evidence")
+    assert crusade.target_score["Pharma"] == 10.0
+    assert 0 <= crusade.get_rage_level() <= 100


### PR DESCRIPTION
## Summary
- track target scores with new `CrusadeMonitor` and expose rage level via `/escalate_target`
- mix an optional outlaw sample into `SonicOrchestrator` and forward rage to visual and sonic streams
- document websim.ai focus and rage monitor usage in README and tests

## Testing
- `python -m py_compile HealthInsurrectionCodex.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c0a6a81d2c8322b84be886cd6d9643