### PR TITLE
Add QUTIP Shader Deco Fusion assets and demo

### DIFF
--- a/qutip-shader-deco-fusion/LICENSE
+++ b/qutip-shader-deco-fusion/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Quantum Graphics Collective
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/qutip-shader-deco-fusion/README.md
+++ b/qutip-shader-deco-fusion/README.md
@@ -1,0 +1,50 @@
+# QUTIP Shader Deco Fusion
+
+**QUTIP Shader Deco Fusion** demonstrates how quantum phase-damping dynamics simulated with [QuTiP](https://qutip.org/) can inform optimised real-time volumetric fog rendering on the GPU. The package contains:
+
+- A runnable WebGL demo tuned for [websim.ai](https://websim.ai) that visualises a cloud/fog volume with a toggleable FPS overlay.
+- Baseline and optimised shader sources (GLSL) plus a WGSL starter that mirrors the same math for WebGPU pipelines.
+- A Python notebook-style script that reproduces the dephasing curve of the off-diagonal density-matrix term (ρ₀₁) and exports the attenuation factors used by the shader.
+- Documentation aligning the mathematical model with the GPU implementation.
+
+## Quick start
+
+### Web demo
+
+1. Open `demo/index.html` in a modern browser or the websim.ai static host.
+2. Click **Toggle FPS** to show or hide the performance panel.
+3. Explore the shader parameters through the live UI sliders.
+
+### Python simulation
+
+1. Create a Python 3.10+ environment and install the dependencies:
+   ```bash
+   pip install qutip matplotlib numpy
+   ```
+2. Run the simulation:
+   ```bash
+   python qutip/deco_sim.py
+   ```
+   The script prints the decoherence timescale, saves a CSV of the sampled decay factors, and displays a plot of |ρ₀₁| over time.
+
+## Repository layout
+
+```
+qutip-shader-deco-fusion/
+├── README.md
+├── LICENSE
+├── demo/
+│   └── index.html
+├── docs/
+│   └── whitepaper.md
+├── qutip/
+│   └── deco_sim.py
+└── shaders/
+    ├── baseline.glsl
+    ├── optimized.glsl
+    └── clouds.wgsl
+```
+
+## Attribution
+
+Released under the MIT License. See `LICENSE` for details.

--- a/qutip-shader-deco-fusion/demo/index.html
+++ b/qutip-shader-deco-fusion/demo/index.html
@@ -1,0 +1,366 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>QUTIP Shader Deco Fusion Demo</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+        background: radial-gradient(circle at 20% 20%, #101525, #020308 80%);
+        color: #e9f0ff;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+      }
+
+      main {
+        width: min(960px, 100vw);
+        margin: 1.5rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: clamp(1.8rem, 2.5vw, 2.8rem);
+      }
+
+      canvas {
+        width: 100%;
+        aspect-ratio: 16 / 9;
+        border-radius: 18px;
+        background: #000;
+        box-shadow: 0 20px 60px rgba(6, 14, 45, 0.35);
+      }
+
+      .panel {
+        background: rgba(6, 12, 30, 0.8);
+        border: 1px solid rgba(90, 122, 255, 0.3);
+        border-radius: 14px;
+        padding: 1rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1rem;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .panel label {
+        display: grid;
+        gap: 0.25rem;
+        font-size: 0.9rem;
+      }
+
+      input[type="range"] {
+        width: 180px;
+      }
+
+      button {
+        padding: 0.6rem 1.2rem;
+        border-radius: 999px;
+        border: 1px solid rgba(111, 138, 255, 0.45);
+        background: linear-gradient(120deg, rgba(46, 92, 255, 0.25), rgba(148, 92, 255, 0.25));
+        color: inherit;
+        cursor: pointer;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 14px 35px rgba(62, 118, 255, 0.25);
+      }
+
+      #fps-panel {
+        display: none;
+        position: absolute;
+        top: 1rem;
+        right: 1rem;
+        padding: 0.5rem 0.75rem;
+        border-radius: 10px;
+        background: rgba(3, 5, 12, 0.82);
+        border: 1px solid rgba(121, 149, 255, 0.35);
+        font-variant-numeric: tabular-nums;
+      }
+
+      footer {
+        font-size: 0.8rem;
+        opacity: 0.7;
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>QUTIP Shader Deco Fusion</h1>
+        <p>
+          Quantum-informed volumetric fog rendered in WebGL. Adjust the density, decoherence
+          rate, and sampling depth to feel the phase-damping curve from the QuTiP simulation.
+        </p>
+      </header>
+
+      <section class="panel">
+        <label>
+          Density
+          <input id="density" type="range" min="0.1" max="1.5" step="0.01" value="0.55" />
+        </label>
+        <label>
+          Decoherence (γ)
+          <input id="gamma" type="range" min="0.05" max="1.5" step="0.01" value="0.28" />
+        </label>
+        <label>
+          Steps
+          <input id="steps" type="range" min="16" max="128" step="1" value="64" />
+        </label>
+        <button id="toggle-fps">Toggle FPS</button>
+      </section>
+
+      <canvas id="gl"></canvas>
+      <div id="fps-panel">FPS: <span id="fps-value">0</span></div>
+
+      <footer>
+        Model: ρ₀₁(t) = ρ₀₁(0) · exp(-γt) sampled from QuTiP → applied as optical depth decay.
+      </footer>
+    </main>
+
+    <script type="module">
+      const canvas = document.getElementById("gl");
+      const gl = canvas.getContext("webgl2", { antialias: false, alpha: false });
+
+      if (!gl) {
+        document.body.innerHTML =
+          "<main><h2>WebGL 2 is required</h2><p>Your browser does not support WebGL2 or it is disabled.</p></main>";
+        throw new Error("WebGL2 not supported");
+      }
+
+      const DPR = Math.min(window.devicePixelRatio || 1, 2);
+
+      // Example to drive gamma with a CSV exported from QuTiP:
+      // fetch('../qutip/decoherence_samples.csv').then(r => r.text()).then(console.log);
+
+      const vertexSource = `#version 300 es
+        layout(location = 0) in vec2 position;
+        out vec2 vUv;
+        void main() {
+          vUv = position * 0.5 + 0.5;
+          gl_Position = vec4(position, 0.0, 1.0);
+        }
+      `;
+
+      const fragmentSource = `#version 300 es
+        precision highp float;
+
+        in vec2 vUv;
+        out vec4 fragColor;
+
+        uniform float uTime;
+        uniform vec2 uResolution;
+        uniform float uDensity;
+        uniform float uGamma;
+        uniform int uSteps;
+
+        const float PI = 3.14159265359;
+
+        float hash(vec3 p) {
+          return fract(sin(dot(p, vec3(12.9898, 78.233, 32.019))) * 43758.5453);
+        }
+
+        float noise(vec3 p) {
+          vec3 i = floor(p);
+          vec3 f = fract(p);
+          vec3 u = f * f * (3.0 - 2.0 * f);
+
+          float n000 = hash(i + vec3(0.0, 0.0, 0.0));
+          float n001 = hash(i + vec3(0.0, 0.0, 1.0));
+          float n010 = hash(i + vec3(0.0, 1.0, 0.0));
+          float n011 = hash(i + vec3(0.0, 1.0, 1.0));
+          float n100 = hash(i + vec3(1.0, 0.0, 0.0));
+          float n101 = hash(i + vec3(1.0, 0.0, 1.0));
+          float n110 = hash(i + vec3(1.0, 1.0, 0.0));
+          float n111 = hash(i + vec3(1.0, 1.0, 1.0));
+
+          float n00 = mix(n000, n100, u.x);
+          float n01 = mix(n001, n101, u.x);
+          float n10 = mix(n010, n110, u.x);
+          float n11 = mix(n011, n111, u.x);
+
+          float n0 = mix(n00, n10, u.y);
+          float n1 = mix(n01, n11, u.y);
+
+          return mix(n0, n1, u.z);
+        }
+
+        float fbm(vec3 p) {
+          float amplitude = 0.5;
+          float frequency = 1.0;
+          float sum = 0.0;
+          for (int i = 0; i < 5; ++i) {
+            sum += amplitude * noise(p * frequency);
+            frequency *= 2.03;
+            amplitude *= 0.53;
+          }
+          return sum;
+        }
+
+        vec3 sundir = normalize(vec3(0.6, 0.35, -0.45));
+
+        vec4 march(vec3 ro, vec3 rd, float density, float gamma) {
+          float stepLength = 0.02;
+          float total = 0.0;
+          float light = 0.0;
+          float t = 0.0;
+          float deco = 1.0;
+
+          for (int i = 0; i < 128; ++i) {
+            if (i >= uSteps) break;
+            vec3 pos = ro + rd * t;
+            if (pos.y < -1.2 || pos.y > 1.2) break;
+            float shape = fbm(pos * 1.3 + vec3(0.0, uTime * 0.015, 0.0));
+            float cloud = smoothstep(0.35, 0.75, shape);
+            float attenuated = cloud * density * deco * stepLength;
+            total += attenuated;
+
+            float phase = exp(-gamma * t);
+            deco = mix(deco, phase, 0.4);
+
+            float l = max(dot(normalize(vec3(fbm(pos + 0.3) - fbm(pos - 0.3))), sundir), 0.0);
+            light += l * attenuated;
+
+            t += stepLength;
+            if (total > 1.5) break;
+          }
+
+          return vec4(total, light, deco, t);
+        }
+
+        void main() {
+          vec2 uv = (vUv * 2.0 - 1.0);
+          uv.x *= uResolution.x / uResolution.y;
+
+          vec3 ro = vec3(0.0, 0.0, 3.0);
+          vec3 rd = normalize(vec3(uv, -1.5));
+
+          vec4 res = march(ro, rd, uDensity, uGamma);
+
+          float colorStrength = clamp(res.x, 0.0, 1.0);
+          vec3 fogColor = mix(vec3(0.12, 0.2, 0.35), vec3(0.6, 0.75, 0.95), clamp(res.y * 1.8, 0.0, 1.0));
+          vec3 finalColor = mix(vec3(0.02, 0.04, 0.08), fogColor, 1.0 - exp(-colorStrength * 1.25));
+          float glow = pow(clamp(res.y * 0.9, 0.0, 1.0), 1.6);
+          finalColor += glow * vec3(0.28, 0.44, 0.85);
+
+          fragColor = vec4(finalColor, 1.0);
+        }
+      `;
+
+      function compile(type, source) {
+        const shader = gl.createShader(type);
+        gl.shaderSource(shader, source);
+        gl.compileShader(shader);
+        if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+          const log = gl.getShaderInfoLog(shader);
+          gl.deleteShader(shader);
+          throw new Error(log || "Shader compile error");
+        }
+        return shader;
+      }
+
+      const program = gl.createProgram();
+      gl.attachShader(program, compile(gl.VERTEX_SHADER, vertexSource));
+      gl.attachShader(program, compile(gl.FRAGMENT_SHADER, fragmentSource));
+      gl.linkProgram(program);
+      if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+        throw new Error(gl.getProgramInfoLog(program) || "Program link error");
+      }
+      gl.useProgram(program);
+
+      const quad = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, quad);
+      gl.bufferData(
+        gl.ARRAY_BUFFER,
+        new Float32Array([
+          -1, -1,
+          3, -1,
+          -1, 3,
+        ]),
+        gl.STATIC_DRAW
+      );
+
+      const vao = gl.createVertexArray();
+      gl.bindVertexArray(vao);
+      gl.enableVertexAttribArray(0);
+      gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+
+      const uniforms = {
+        time: gl.getUniformLocation(program, "uTime"),
+        resolution: gl.getUniformLocation(program, "uResolution"),
+        density: gl.getUniformLocation(program, "uDensity"),
+        gamma: gl.getUniformLocation(program, "uGamma"),
+        steps: gl.getUniformLocation(program, "uSteps"),
+      };
+
+      const controls = {
+        density: document.getElementById("density"),
+        gamma: document.getElementById("gamma"),
+        steps: document.getElementById("steps"),
+      };
+
+      const fpsPanel = document.getElementById("fps-panel");
+      const fpsValue = document.getElementById("fps-value");
+      const fpsToggle = document.getElementById("toggle-fps");
+
+      fpsToggle.addEventListener("click", () => {
+        const active = fpsPanel.style.display === "block";
+        fpsPanel.style.display = active ? "none" : "block";
+      });
+
+      function resize() {
+        const width = Math.floor(canvas.clientWidth * DPR);
+        const height = Math.floor(canvas.clientHeight * DPR);
+        if (canvas.width !== width || canvas.height !== height) {
+          canvas.width = width;
+          canvas.height = height;
+        }
+        gl.viewport(0, 0, canvas.width, canvas.height);
+        gl.uniform2f(uniforms.resolution, canvas.width, canvas.height);
+      }
+
+      window.addEventListener("resize", resize);
+      resize();
+
+      let last = performance.now();
+      let frame = 0;
+      let fpsTimer = 0;
+
+      function render(now) {
+        resize();
+        const delta = (now - last) * 0.001;
+        last = now;
+
+        frame++;
+        fpsTimer += delta;
+        if (fpsTimer >= 0.25) {
+          const fps = Math.round((frame / fpsTimer) * 10) / 10;
+          fpsValue.textContent = fps.toString();
+          frame = 0;
+          fpsTimer = 0;
+        }
+
+        gl.uniform1f(uniforms.time, now * 0.001);
+        gl.uniform1f(uniforms.density, parseFloat(controls.density.value));
+        gl.uniform1f(uniforms.gamma, parseFloat(controls.gamma.value));
+        gl.uniform1i(uniforms.steps, parseInt(controls.steps.value));
+
+        gl.drawArrays(gl.TRIANGLES, 0, 3);
+        requestAnimationFrame(render);
+      }
+
+      requestAnimationFrame(render);
+    </script>
+  </body>
+</html>

--- a/qutip-shader-deco-fusion/docs/whitepaper.md
+++ b/qutip-shader-deco-fusion/docs/whitepaper.md
@@ -1,0 +1,53 @@
+# QUTIP Shader Deco Fusion — Whitepaper
+
+## Abstract
+
+This document outlines how quantum open-system simulations performed with QuTiP's phase-damping model can inform physically-inspired volumetric fog rendering. By matching the decoherence profile of the off-diagonal density-matrix element (ρ₀₁) to the exponential attenuation in a ray-marched shader, we create a visualisation where cloud translucency encodes the same decay rate measured in the quantum system.
+
+## 1. Background
+
+- **QuTiP**: The Quantum Toolbox in Python provides master-equation solvers for open quantum systems. Phase damping is modelled using a Lindblad superoperator that attenuates coherences without exchanging energy.
+- **Phase-damping channel**: For a single qubit, ρ₀₁(t) = ρ₀₁(0)·exp(-γt). The parameter γ is the decoherence rate extracted from experiments or theoretical models.
+- **Volumetric rendering**: Ray-marched fog computes optical depth by accumulating density samples along the camera ray. Lighting is approximated by evaluating gradients (normals) inside the volume.
+
+## 2. Workflow overview
+
+1. **Simulate** the decoherence curve with `qutip/deco_sim.py`. The script exports evenly sampled values of |ρ₀₁(t)| to `decoherence_samples.csv`.
+2. **Normalise** the magnitude samples to map them into [0, 1]. These values act as attenuation multipliers that progressively reduce the contribution of distant fog layers.
+3. **Render** the fog inside `demo/index.html`. The WebGL shader receives `uGamma` (γ) and the local step distance `t` to reproduce the same exponential drop observed in the QuTiP output.
+
+## 3. Shader coupling
+
+The fragment shader implements a march routine:
+
+```
+float phase = exp(-gamma * t);
+decoherence = mix(decoherence, phase, 0.55);
+float sample = cloud * density * decoherence;
+```
+
+- `gamma` is controlled by the UI slider and defaults to the value used in the QuTiP simulation (0.28).
+- `decoherence` blends toward `phase`, a direct exponential mapping of the quantum decay curve.
+- The accumulated `sample` forms both the optical depth (absorption) and the scattered light (inscattering) terms.
+
+## 4. Optimisation notes
+
+- Noise sampling uses a hash-based value noise instead of gradient noise to keep the shader small and compatible with WebGL 2.
+- Fractional Brownian motion (fBm) is truncated to six octaves to balance detail and performance. The `Steps` slider exposes the ray-march sample count for interactive profiling.
+- The FPS overlay is implemented entirely in JavaScript to avoid coupling the shader to HTML overlays, ensuring the demo works inside the websim.ai sandbox.
+
+## 5. Extending to WebGPU
+
+`shaders/clouds.wgsl` replicates the GLSL logic using WGSL syntax. Integrate it by:
+
+1. Creating a uniform buffer containing `(resolution, time, density, gamma, steps)`.
+2. Dispatching a full-screen triangle pipeline with the same vertex shader included in the file.
+3. Supplying a storage buffer or texture containing precomputed noise (optional). The current implementation uses the procedural hash to avoid extra resources.
+
+## 6. Data interchange
+
+`deco_sim.py` writes the CSV with four columns: `time`, `real`, `imag`, and `magnitude`. The JavaScript demo includes a helper (commented out) showing how to fetch those values and drive the shader uniforms if you want to bake the profile directly instead of using the analytical exponential.
+
+## 7. License
+
+All assets are released under the MIT license. Contributions and integrations are welcome.

--- a/qutip-shader-deco-fusion/qutip/deco_sim.py
+++ b/qutip-shader-deco-fusion/qutip/deco_sim.py
@@ -1,0 +1,114 @@
+"""Phase damping simulation linking QuTiP results to the volumetric shader.
+
+This script reproduces the |rho_01| decay curve for a single qubit under a
+phase-damping (pure dephasing) channel. The resulting attenuation factors are
+saved to `decoherence_samples.csv` and plotted for quick inspection.
+
+Run with:
+    python deco_sim.py
+"""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Tuple
+
+import numpy as np
+
+try:
+    from qutip import Qobj, basis, mesolve
+    from qutip.operators import sigmax, sigmaz
+except Exception:  # pragma: no cover - optional dependency fallback
+    Qobj = None
+    basis = None
+    mesolve = None
+    sigmax = None
+    sigmaz = None
+
+import matplotlib.pyplot as plt
+
+
+@dataclass
+class PhaseDampingConfig:
+    gamma: float = 0.28  # decoherence rate (1/time units)
+    t_max: float = 6.0   # simulation window
+    samples: int = 240   # number of sample points
+
+
+@dataclass
+class SimulationResult:
+    times: np.ndarray
+    rho01: np.ndarray
+
+
+def simulate_with_qutip(cfg: PhaseDampingConfig) -> SimulationResult:
+    if mesolve is None:
+        raise RuntimeError("QuTiP is not available. Install it with `pip install qutip`." )
+
+    # Initial state |+> (superposition of |0> and |1>)
+    psi0 = (basis(2, 0) + basis(2, 1)).unit()
+    rho0 = psi0 * psi0.dag()
+
+    # Phase damping Lindblad operator
+    L = np.sqrt(cfg.gamma / 2.0) * sigmaz()
+
+    times = np.linspace(0.0, cfg.t_max, cfg.samples, dtype=float)
+    result = mesolve(H=sigmax() * 0.0, rho0=rho0, tlist=times, c_ops=[L], e_ops=[])
+
+    rho01 = np.array([state[0, 1] for state in result.states], dtype=complex)
+    return SimulationResult(times=times, rho01=rho01)
+
+
+def simulate_analytical(cfg: PhaseDampingConfig) -> SimulationResult:
+    times = np.linspace(0.0, cfg.t_max, cfg.samples, dtype=float)
+    rho01 = 0.5 * np.exp(-cfg.gamma * times)
+    return SimulationResult(times=times, rho01=rho01.astype(complex))
+
+
+def export_csv(times: Iterable[float], rho01: Iterable[complex], path: Path) -> None:
+    with path.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["time", "real", "imag", "magnitude"])
+        for t, c in zip(times, rho01):
+            writer.writerow([f"{t:.6f}", f"{c.real:.6f}", f"{c.imag:.6f}", f"{abs(c):.6f}"])
+
+
+def main() -> Tuple[SimulationResult, SimulationResult]:
+    cfg = PhaseDampingConfig()
+    qutip_result: SimulationResult
+
+    try:
+        qutip_result = simulate_with_qutip(cfg)
+        print("QuTiP detected: using Lindblad master equation for simulation.")
+    except Exception as exc:
+        print(f"QuTiP unavailable ({exc}). Falling back to analytical exponential decay.")
+        qutip_result = simulate_analytical(cfg)
+
+    analytic_result = simulate_analytical(cfg)
+
+    out_dir = Path(__file__).resolve().parent
+    csv_path = out_dir / "decoherence_samples.csv"
+    export_csv(qutip_result.times, qutip_result.rho01, csv_path)
+    print(f"Saved sample curve to {csv_path.relative_to(Path.cwd())}")
+
+    plt.figure(figsize=(7.5, 4.2))
+    plt.plot(qutip_result.times, np.abs(qutip_result.rho01), label="|rho01| (simulated)", linewidth=2.2)
+    plt.plot(analytic_result.times, np.abs(analytic_result.rho01), label="|rho01| = 0.5·exp(-γt)", linestyle="--")
+    plt.title("Phase damping decay of off-diagonal term ρ₀₁")
+    plt.xlabel("time")
+    plt.ylabel("magnitude")
+    plt.grid(alpha=0.25)
+    plt.legend()
+    plt.tight_layout()
+    plt.show()
+
+    decoherence_time = 1.0 / cfg.gamma
+    print(f"Decoherence 1/e time: {decoherence_time:.2f} time units")
+
+    return qutip_result, analytic_result
+
+
+if __name__ == "__main__":
+    main()

--- a/qutip-shader-deco-fusion/shaders/baseline.glsl
+++ b/qutip-shader-deco-fusion/shaders/baseline.glsl
@@ -1,0 +1,61 @@
+// baseline.glsl
+// Simple volumetric fog shader using a naive phase-damping lookup.
+
+#version 300 es
+precision highp float;
+
+in vec2 vUv;
+out vec4 fragColor;
+
+uniform float uTime;
+uniform vec2 uResolution;
+uniform float uDensity;
+
+float hash(vec3 p) {
+    return fract(sin(dot(p, vec3(12.9898, 78.233, 151.718))) * 43758.5453);
+}
+
+float noise(vec3 p) {
+    vec3 i = floor(p);
+    vec3 f = fract(p);
+    vec3 u = f * f * (3.0 - 2.0 * f);
+
+    float n000 = hash(i + vec3(0.0, 0.0, 0.0));
+    float n001 = hash(i + vec3(0.0, 0.0, 1.0));
+    float n010 = hash(i + vec3(0.0, 1.0, 0.0));
+    float n011 = hash(i + vec3(0.0, 1.0, 1.0));
+    float n100 = hash(i + vec3(1.0, 0.0, 0.0));
+    float n101 = hash(i + vec3(1.0, 0.0, 1.0));
+    float n110 = hash(i + vec3(1.0, 1.0, 0.0));
+    float n111 = hash(i + vec3(1.0, 1.0, 1.0));
+
+    float n00 = mix(n000, n100, u.x);
+    float n01 = mix(n001, n101, u.x);
+    float n10 = mix(n010, n110, u.x);
+    float n11 = mix(n011, n111, u.x);
+
+    float n0 = mix(n00, n10, u.y);
+    float n1 = mix(n01, n11, u.y);
+
+    return mix(n0, n1, u.z);
+}
+
+void main() {
+    vec2 uv = vUv * 2.0 - 1.0;
+    uv.x *= uResolution.x / uResolution.y;
+
+    vec3 rayOrigin = vec3(0.0, 0.0, 3.0);
+    vec3 rayDir = normalize(vec3(uv, -1.5));
+
+    float density = 0.0;
+    float stepSize = 0.04;
+
+    for (int i = 0; i < 48; ++i) {
+        vec3 pos = rayOrigin + rayDir * float(i) * stepSize;
+        float shape = noise(pos * 1.1 + uTime * 0.02);
+        density += smoothstep(0.35, 0.75, shape) * uDensity * stepSize;
+    }
+
+    vec3 fogColor = mix(vec3(0.08, 0.12, 0.2), vec3(0.5, 0.72, 0.92), clamp(density, 0.0, 1.0));
+    fragColor = vec4(fogColor, 1.0);
+}

--- a/qutip-shader-deco-fusion/shaders/clouds.wgsl
+++ b/qutip-shader-deco-fusion/shaders/clouds.wgsl
@@ -1,0 +1,121 @@
+// clouds.wgsl
+// WebGPU stub mirroring the GLSL implementation. Integrate into your pipeline by
+// binding the uniforms buffer with time, density, gamma, resolution, and step count.
+
+struct Uniforms {
+    resolution : vec2<f32>,
+    time : f32,
+    density : f32,
+    gamma : f32,
+    steps : u32,
+};
+
+@group(0) @binding(0)
+var<uniform> uniforms : Uniforms;
+
+struct VertexOutput {
+    @builtin(position) clip_position : vec4<f32>,
+    @location(0) uv : vec2<f32>,
+};
+
+@vertex
+fn vs_main(@location(0) position : vec2<f32>) -> VertexOutput {
+    var out : VertexOutput;
+    out.clip_position = vec4<f32>(position, 0.0, 1.0);
+    out.uv = position * 0.5 + vec2<f32>(0.5);
+    return out;
+}
+
+fn hash(p : vec3<f32>) -> f32 {
+    return fract(sin(dot(p, vec3<f32>(12.9898, 78.233, 45.164))) * 43758.5453);
+}
+
+fn noise(p : vec3<f32>) -> f32 {
+    let i = floor(p);
+    let f = fract(p);
+    let u = f * f * (3.0 - 2.0 * f);
+
+    let n000 = hash(i + vec3<f32>(0.0, 0.0, 0.0));
+    let n001 = hash(i + vec3<f32>(0.0, 0.0, 1.0));
+    let n010 = hash(i + vec3<f32>(0.0, 1.0, 0.0));
+    let n011 = hash(i + vec3<f32>(0.0, 1.0, 1.0));
+    let n100 = hash(i + vec3<f32>(1.0, 0.0, 0.0));
+    let n101 = hash(i + vec3<f32>(1.0, 0.0, 1.0));
+    let n110 = hash(i + vec3<f32>(1.0, 1.0, 0.0));
+    let n111 = hash(i + vec3<f32>(1.0, 1.0, 1.0));
+
+    let n00 = mix(n000, n100, u.x);
+    let n01 = mix(n001, n101, u.x);
+    let n10 = mix(n010, n110, u.x);
+    let n11 = mix(n011, n111, u.x);
+
+    let n0 = mix(n00, n10, u.y);
+    let n1 = mix(n01, n11, u.y);
+
+    return mix(n0, n1, u.z);
+}
+
+fn fbm(p : vec3<f32>) -> f32 {
+    var amplitude = 0.55;
+    var frequency = 1.2;
+    var sum = 0.0;
+    for (var i = 0; i < 5; i = i + 1) {
+        sum = sum + amplitude * noise(p * frequency);
+        frequency = frequency * 2.17;
+        amplitude = amplitude * 0.47;
+    }
+    return sum;
+}
+
+struct FragmentOutput {
+    @location(0) color : vec4<f32>,
+};
+
+@fragment
+fn fs_main(in : VertexOutput) -> FragmentOutput {
+    var out : FragmentOutput;
+    var uv = in.uv * 2.0 - vec2<f32>(1.0);
+    uv.x = uv.x * (uniforms.resolution.x / uniforms.resolution.y);
+
+    let ro = vec3<f32>(0.0, 0.1, 3.0);
+    var rd = normalize(vec3<f32>(uv, -1.35));
+
+    var optical_depth = 0.0;
+    var scattered = 0.0;
+    var decoherence = 1.0;
+    let step_length = 2.8 / f32(uniforms.steps);
+    let light_dir = normalize(vec3<f32>(0.6, 0.4, -0.3));
+
+    for (var i = 0u; i < uniforms.steps; i = i + 1u) {
+        let t = f32(i) * step_length;
+        let pos = ro + rd * t;
+        if (abs(pos.y) > 1.4) { break; }
+
+        let field = fbm(pos * 1.35 + vec3<f32>(0.0, uniforms.time * 0.012, 0.1 * uniforms.time));
+        let cloud = smoothstep(0.32, 0.78, field);
+        let sample = cloud * uniforms.density * decoherence;
+        optical_depth = optical_depth + sample * step_length;
+
+        let phase = exp(-uniforms.gamma * t);
+        decoherence = mix(decoherence, phase, 0.55);
+
+        let normal = normalize(vec3<f32>(
+            fbm(pos + vec3<f32>(0.2, 0.0, 0.0)) - fbm(pos - vec3<f32>(0.2, 0.0, 0.0)),
+            fbm(pos + vec3<f32>(0.0, 0.2, 0.0)) - fbm(pos - vec3<f32>(0.0, 0.2, 0.0)),
+            fbm(pos + vec3<f32>(0.0, 0.0, 0.2)) - fbm(pos - vec3<f32>(0.0, 0.0, 0.2))
+        ));
+        let light = max(dot(normal, light_dir), 0.0) + 0.2;
+        scattered = scattered + light * sample * step_length;
+
+        if (optical_depth > 2.2) { break; }
+    }
+
+    let depth = clamp(optical_depth, 0.0, 3.0);
+    let fade = 1.0 - exp(-depth * 1.1);
+    var color = mix(vec3<f32>(0.05, 0.1, 0.18), vec3<f32>(0.7, 0.8, 0.95), fade);
+    color = color + pow(clamp(scattered * 0.85, 0.0, 1.0), 1.3) * vec3<f32>(0.25, 0.38, 0.9);
+    color = color * mix(0.92, 1.08, clamp(decoherence, 0.4, 1.0));
+
+    out.color = vec4<f32>(color, 1.0);
+    return out;
+}

--- a/qutip-shader-deco-fusion/shaders/optimized.glsl
+++ b/qutip-shader-deco-fusion/shaders/optimized.glsl
@@ -1,0 +1,118 @@
+// optimized.glsl
+// Optimised volumetric fog shader coupling QuTiP phase damping into ray-marched density.
+
+#version 300 es
+precision highp float;
+
+in vec2 vUv;
+out vec4 fragColor;
+
+uniform float uTime;
+uniform vec2 uResolution;
+uniform float uDensity;
+uniform float uGamma;
+uniform int uSteps;
+
+#define FAST_HASH(p) fract(sin(dot(p, vec3(12.9898, 78.233, 45.164))) * 43758.5453)
+
+float noise(vec3 p) {
+    vec3 i = floor(p);
+    vec3 f = fract(p);
+    vec3 u = f * f * (3.0 - 2.0 * f);
+
+    float n000 = FAST_HASH(i + vec3(0.0));
+    float n001 = FAST_HASH(i + vec3(0.0, 0.0, 1.0));
+    float n010 = FAST_HASH(i + vec3(0.0, 1.0, 0.0));
+    float n011 = FAST_HASH(i + vec3(0.0, 1.0, 1.0));
+    float n100 = FAST_HASH(i + vec3(1.0, 0.0, 0.0));
+    float n101 = FAST_HASH(i + vec3(1.0, 0.0, 1.0));
+    float n110 = FAST_HASH(i + vec3(1.0, 1.0, 0.0));
+    float n111 = FAST_HASH(i + vec3(1.0));
+
+    float n00 = mix(n000, n100, u.x);
+    float n01 = mix(n001, n101, u.x);
+    float n10 = mix(n010, n110, u.x);
+    float n11 = mix(n011, n111, u.x);
+
+    float n0 = mix(n00, n10, u.y);
+    float n1 = mix(n01, n11, u.y);
+
+    return mix(n0, n1, u.z);
+}
+
+float fbm(vec3 p) {
+    float amplitude = 0.55;
+    float frequency = 1.2;
+    float sum = 0.0;
+    for (int i = 0; i < 6; ++i) {
+        sum += amplitude * noise(p * frequency);
+        frequency *= 2.17;
+        amplitude *= 0.47;
+    }
+    return sum;
+}
+
+vec3 computeNormal(vec3 p) {
+    float e = 0.2;
+    vec3 grad = vec3(
+        fbm(p + vec3(e, 0.0, 0.0)) - fbm(p - vec3(e, 0.0, 0.0)),
+        fbm(p + vec3(0.0, e, 0.0)) - fbm(p - vec3(0.0, e, 0.0)),
+        fbm(p + vec3(0.0, 0.0, e)) - fbm(p - vec3(0.0, 0.0, e))
+    );
+    return normalize(grad);
+}
+
+vec4 march(vec3 ro, vec3 rd, float density, float gamma, int steps) {
+    float t = 0.0;
+    float stepLength = 2.8 / float(steps);
+    float opticalDepth = 0.0;
+    float scattered = 0.0;
+    float decoherence = 1.0;
+
+    vec3 lightDir = normalize(vec3(0.6, 0.4, -0.3));
+
+    for (int i = 0; i < 192; ++i) {
+        if (i >= steps) break;
+        vec3 pos = ro + rd * t;
+        if (abs(pos.y) > 1.4) break;
+
+        float field = fbm(pos * 1.35 + vec3(0.0, uTime * 0.012, 0.1 * uTime));
+        float cloud = smoothstep(0.32, 0.78, field);
+
+        float sample = cloud * density * decoherence;
+        opticalDepth += sample * stepLength;
+
+        float phase = exp(-gamma * t);
+        decoherence = mix(decoherence, phase, 0.55);
+
+        vec3 normal = computeNormal(pos * 0.9);
+        float light = max(dot(normal, lightDir), 0.0) + 0.2;
+        scattered += light * sample * stepLength;
+
+        t += stepLength;
+        if (opticalDepth > 2.2) break;
+    }
+
+    return vec4(opticalDepth, scattered, decoherence, t);
+}
+
+void main() {
+    vec2 uv = vUv * 2.0 - 1.0;
+    uv.x *= uResolution.x / uResolution.y;
+
+    vec3 ro = vec3(0.0, 0.1, 3.0);
+    vec3 rd = normalize(vec3(uv, -1.35));
+
+    vec4 res = march(ro, rd, uDensity, uGamma, uSteps);
+
+    float depth = clamp(res.x, 0.0, 3.0);
+    float fade = 1.0 - exp(-depth * 1.1);
+    vec3 baseColor = vec3(0.05, 0.1, 0.18);
+    vec3 scatterColor = mix(vec3(0.2, 0.42, 0.7), vec3(0.74, 0.84, 0.95), clamp(res.y * 1.5, 0.0, 1.0));
+
+    vec3 color = mix(baseColor, scatterColor, fade);
+    color += pow(clamp(res.y * 0.85, 0.0, 1.0), 1.3) * vec3(0.25, 0.38, 0.9);
+    color *= mix(0.92, 1.08, clamp(res.z, 0.4, 1.0));
+
+    fragColor = vec4(color, 1.0);
+}


### PR DESCRIPTION
## Summary
- add QUTIP Shader Deco Fusion package with documentation, shaders, and MIT license
- implement a websim.ai-friendly WebGL demo featuring volumetric fog controls and FPS toggle
- include QuTiP-aligned phase damping simulation script plus WGSL stub for WebGPU pipelines

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68da5c69643c8322938ca977b0b05f69